### PR TITLE
[13.0] [FIX] website_sale_cart_decimals: Decimal bugs in the cart

### DIFF
--- a/website_sale_cart_decimals/README.rst
+++ b/website_sale_cart_decimals/README.rst
@@ -19,7 +19,9 @@ Website Sale Cart Decimals
 
 |badge1| |badge2| |badge3| 
 
-Shows decimals in "My Cart" quantity summary.
+This addon modifies the official Odoo Sale ``onClickAddCartJSON`` method to round cart quantities to two decimal places and shows decimals in "My Cart" quantity summary. 
+
+The current source matches (without modifications) to https://github.com/odoo/odoo/commit/ab621e524ffbf3841d6bf6c152aae825c9202a4c . If it's used in a later version of Odoo, use this SHA-1 to get differences add update this implementation, if required.
 
 **Table of contents**
 

--- a/website_sale_cart_decimals/__manifest__.py
+++ b/website_sale_cart_decimals/__manifest__.py
@@ -7,13 +7,14 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.0.2",
     "category": "Website",
     "website": "https://github.com/solvosci/slv-e-commerce",
     "depends": [
         "website_sale",
     ],
     "data": [
+        "views/website_sale_cart_decimals.xml",
     ],
     'installable': True,
 }

--- a/website_sale_cart_decimals/models/sale_order.py
+++ b/website_sale_cart_decimals/models/sale_order.py
@@ -9,9 +9,10 @@ class SaleOrder(models.Model):
     
     cart_quantity = fields.Float(compute='_compute_cart_info')
     
+    #To do a more complete rounding for odoo
     def _compute_cart_info(self):
         super()._compute_cart_info()
         for order in self:
             order.cart_quantity = float(
-                sum(order.mapped('website_order_line.product_uom_qty'))
+                round(sum(order.mapped('website_order_line.product_uom_qty')), 2)
             )

--- a/website_sale_cart_decimals/readme/DESCRIPTION.rst
+++ b/website_sale_cart_decimals/readme/DESCRIPTION.rst
@@ -1,1 +1,3 @@
-Shows decimals in "My Cart" quantity summary.
+This addon modifies the official Odoo Sale ``onClickAddCartJSON`` method to round cart quantities to two decimal places and shows decimals in "My Cart" quantity summary. 
+
+The current source matches (without modifications) to https://github.com/odoo/odoo/commit/ab621e524ffbf3841d6bf6c152aae825c9202a4c . If it's used in a later version of Odoo, use this SHA-1 to get differences add update this implementation, if required.

--- a/website_sale_cart_decimals/static/description/index.html
+++ b/website_sale_cart_decimals/static/description/index.html
@@ -368,7 +368,8 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/solvosci/slv-e-commerce/tree/13.0/website_sale_cart_decimals"><img alt="solvosci/slv-e-commerce" src="https://img.shields.io/badge/github-solvosci%2Fslv--e--commerce-lightgray.png?logo=github" /></a></p>
-<p>Shows decimals in “My Cart” quantity summary.</p>
+<p>This addon modifies the official Odoo Sale <tt class="docutils literal">onClickAddCartJSON</tt> method to round cart quantities to two decimal places and shows decimals in “My Cart” quantity summary.</p>
+<p>The current source matches (without modifications) to <a class="reference external" href="https://github.com/odoo/odoo/commit/ab621e524ffbf3841d6bf6c152aae825c9202a4c">https://github.com/odoo/odoo/commit/ab621e524ffbf3841d6bf6c152aae825c9202a4c</a> . If it’s used in a later version of Odoo, use this SHA-1 to get differences add update this implementation, if required.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/website_sale_cart_decimals/static/src/js/variant_mixin.js
+++ b/website_sale_cart_decimals/static/src/js/variant_mixin.js
@@ -1,0 +1,28 @@
+/*  © 2021 Solvos Consultoría Informática (<http://www.solvos.es>)
+    License LGPL-3.0 (http://www.gnu.org/licenses/lgpl-3.0.html)
+*/
+
+odoo.define('website_sale_cart_decimals.widgets', function (require) {
+    "use strict";
+
+    var variant_mixin = require('sale.VariantMixin');
+
+    variant_mixin.onClickAddCartJSON = function (ev) {
+        ev.preventDefault();
+        var $link = $(ev.currentTarget);
+        var $input = $link.closest('.input-group').find("input");
+        var min = parseFloat($input.data("min") || 0);
+        var max = parseFloat($input.data("max") || Infinity);
+        var previousQty = parseFloat($input.val() || 0, 10);
+        var quantity = ($link.has(".fa-minus").length ? -1 : 1) + previousQty;
+        var newQty = quantity > min ? (quantity < max ? quantity : max) : min;
+
+        //Round the quantity of the product by possible errors when adding decimals 
+        newQty = Math.round(newQty * 100) / 100;
+
+        if (newQty !== previousQty) {
+            $input.val(newQty).trigger('change');
+        }
+        return false;
+    };
+});

--- a/website_sale_cart_decimals/views/website_sale_cart_decimals.xml
+++ b/website_sale_cart_decimals/views/website_sale_cart_decimals.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="website_sale_cart_decimals.assets_frontend" inherit_id="website.assets_frontend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/website_sale_cart_decimals/static/src/js/variant_mixin.js" />
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
Fix two bugs:
Round the total quantity of a cart 
![imagen](https://user-images.githubusercontent.com/22427989/112615844-4a828780-8e23-11eb-99ce-d73f406a3a90.png)
When you click on the plus or minus round the quantity
![imagen](https://user-images.githubusercontent.com/22427989/112615942-70a82780-8e23-11eb-96b8-9a9c7af089bd.png)
