### PR TITLE
[15.0] [FIX] website_sale_product_custom_fields: allow all users to view complements in popup

### DIFF
--- a/website_sale_product_custom_fields/__manifest__.py
+++ b/website_sale_product_custom_fields/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.1.0.0",
+    "version": "15.0.2.0.0",
     "category": "Website",
     "website": "https://github.com/solvosci/slv-e-commerce",
     "depends": [
@@ -21,6 +21,8 @@
         ],
     },
     'data': [
+        'security/ir_rule_data.xml',
+        'views/complement_popup_template.xml',
         'views/product_template_views.xml',
         'views/website_sale_product_template_inherit.xml'
     ],

--- a/website_sale_product_custom_fields/controllers/__init__.py
+++ b/website_sale_product_custom_fields/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import main
+from . import product_controller

--- a/website_sale_product_custom_fields/controllers/main.py
+++ b/website_sale_product_custom_fields/controllers/main.py
@@ -37,6 +37,7 @@ class CustomWebsiteSale(WebsiteSale):
         self._create_cart_line(line, response, order, product_id, qty, **custom_values)
 
         for line in order.order_line:
+            self.complement_size(line)
             self._update_price(line)
 
         return response
@@ -64,12 +65,23 @@ class CustomWebsiteSale(WebsiteSale):
             base_price = line.adv_unitary_product_price or 0.0
 
             if line.adv_complement_id:
-                complement_price = request.env['product.template'].browse(int(line.adv_complement_id.id)).list_price or 0.0
+                complement_price = request.env['product.template'].sudo().browse(int(line.adv_complement_id.id)).list_price or 0.0
 
             if line.adv_modification_id:
                 modification_price = request.env['sale.order.line.modification'].sudo().browse(int(line.adv_modification_id.id)).price or 0.0
 
             line.price_unit = base_price + complement_price + modification_price
+
+    def complement_size(self, line):
+        product_values = line.product_id.product_template_attribute_value_ids.mapped("product_attribute_value_id")
+        if product_values:
+            equivalence = request.env["product.complement.size"].sudo().search([
+                ("product_size_ids", "in", product_values.ids),
+                ("active", "=", True)
+            ], limit=1)
+            line.adv_complement_size = equivalence.name
+            line.adv_complement_group = f"{line.adv_complement_id.name} | {equivalence.name}".strip()
+
 
     @staticmethod
     def _get_tailored_characteristics(**kw):

--- a/website_sale_product_custom_fields/controllers/product_controller.py
+++ b/website_sale_product_custom_fields/controllers/product_controller.py
@@ -1,0 +1,43 @@
+# © 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3 - See http://www.gnu.org/licenses/lgpl-3.0.html
+
+from odoo import http
+from odoo.http import request
+
+
+class ProductComplements(http.Controller):
+
+    @http.route('/website/complements/get_products', type='json', auth="public", methods=['POST'], website=True)
+    def get_complementary_products(self, product_id):
+
+        product = request.env['product.template'].sudo().browse(int(product_id))
+        complement_data = []
+
+        for category_id in product.complement_category_ids.sudo():
+            complement_products = request.env['product.template'].sudo().search([
+                ('categ_id', '=', category_id.id)
+            ])
+
+            if complement_products:
+                products_list = []
+                for p in complement_products:
+                    products_list.append({
+                        'id': p.id,
+                        'name': p.name,
+                        'list_price': p.list_price,
+                        'currency_symbol': p.currency_id.symbol,
+                        'variant_price': p.product_variant_ids and p.product_variant_ids[0].lst_price or p.list_price,
+                    })
+
+                complement_data.append({
+                    'category_name': category_id.name,
+                    'products': products_list,
+                })
+
+        return request.env['ir.ui.view']._render_template(
+            'website_sale_product_custom_fields.complement_popup_content',
+            {
+                'complement_data': complement_data,
+                'product': product.sudo(),
+            }
+        )

--- a/website_sale_product_custom_fields/i18n/es.po
+++ b/website_sale_product_custom_fields/i18n/es.po
@@ -6,14 +6,25 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-16 07:55+0000\n"
-"PO-Revision-Date: 2025-07-16 07:55+0000\n"
+"POT-Creation-Date: 2025-10-16 06:28+0000\n"
+"PO-Revision-Date: 2025-10-16 06:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: website_sale_product_custom_fields
+#. openerp-web
+#: code:addons/website_sale_product_custom_fields/static/src/js/custom_script.js:0
+#, python-format
+msgid ""
+"<div class=\"text-center p-5\"><div class=\"spinner-border\" "
+"role=\"status\"></div><p class=\"mt-2\">Loading complements...</p></div>"
+msgstr ""
+"<div class=\"text-center p-5\"><div class=\"spinner-border\" "
+"role=\"status\"></div><p class=\"mt-2\">Cargando complementos...</p></div>"
 
 #. module: website_sale_product_custom_fields
 #: model_terms:ir.ui.view,arch_db:website_sale_product_custom_fields.product_custom_fields
@@ -33,6 +44,20 @@ msgid "<option value=\"\" disabled=\"true\" selected=\"true\">Select a value</op
 msgstr ""
 "<option value=\"\" disabled=\"true\" selected=\"true\">Selecciona un "
 "valor</option>"
+
+#. module: website_sale_product_custom_fields
+#. openerp-web
+#: code:addons/website_sale_product_custom_fields/static/src/js/custom_script.js:0
+#, python-format
+msgid "<p class=\"text-danger p-3\">Error loading complements.</p>"
+msgstr "<p class=\"text-danger p-3\">Error cargando complementos.</p>"
+
+#. module: website_sale_product_custom_fields
+#. openerp-web
+#: code:addons/website_sale_product_custom_fields/static/src/js/custom_script.js:0
+#, python-format
+msgid "<p class=\"text-danger p-3\">Error: "
+msgstr "<p class=\"text-danger p-3\">Error: "
 
 #. module: website_sale_product_custom_fields
 #: model_terms:ir.ui.view,arch_db:website_sale_product_custom_fields.product_custom_fields
@@ -155,6 +180,11 @@ msgstr "Largo de casaca"
 #: model:ir.model.fields,field_description:website_sale_product_custom_fields.field_product_template__kid_gender
 msgid "Kid Gender"
 msgstr "Género del niño"
+
+#. module: website_sale_product_custom_fields
+#: model_terms:ir.ui.view,arch_db:website_sale_product_custom_fields.product_custom_fields
+msgid "Loading complements..."
+msgstr "Cargando complementos..."
 
 #. module: website_sale_product_custom_fields
 #: model_terms:ir.ui.view,arch_db:website_sale_product_custom_fields.product_custom_fields

--- a/website_sale_product_custom_fields/i18n/website_sale_product_custom_fields.pot
+++ b/website_sale_product_custom_fields/i18n/website_sale_product_custom_fields.pot
@@ -6,14 +6,23 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-16 07:55+0000\n"
-"PO-Revision-Date: 2025-07-16 07:55+0000\n"
+"POT-Creation-Date: 2025-10-16 06:28+0000\n"
+"PO-Revision-Date: 2025-10-16 06:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: website_sale_product_custom_fields
+#. openerp-web
+#: code:addons/website_sale_product_custom_fields/static/src/js/custom_script.js:0
+#, python-format
+msgid ""
+"<div class=\"text-center p-5\"><div class=\"spinner-border\" "
+"role=\"status\"></div><p class=\"mt-2\">Loading complements...</p></div>"
+msgstr ""
 
 #. module: website_sale_product_custom_fields
 #: model_terms:ir.ui.view,arch_db:website_sale_product_custom_fields.product_custom_fields
@@ -28,6 +37,20 @@ msgstr ""
 #. module: website_sale_product_custom_fields
 #: model_terms:ir.ui.view,arch_db:website_sale_product_custom_fields.product_custom_fields
 msgid "<option value=\"\" disabled=\"true\" selected=\"true\">Select a value</option>"
+msgstr ""
+
+#. module: website_sale_product_custom_fields
+#. openerp-web
+#: code:addons/website_sale_product_custom_fields/static/src/js/custom_script.js:0
+#, python-format
+msgid "<p class=\"text-danger p-3\">Error loading complements.</p>"
+msgstr ""
+
+#. module: website_sale_product_custom_fields
+#. openerp-web
+#: code:addons/website_sale_product_custom_fields/static/src/js/custom_script.js:0
+#, python-format
+msgid "<p class=\"text-danger p-3\">Error: "
 msgstr ""
 
 #. module: website_sale_product_custom_fields
@@ -146,6 +169,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:website_sale_product_custom_fields.field_product_product__kid_gender
 #: model:ir.model.fields,field_description:website_sale_product_custom_fields.field_product_template__kid_gender
 msgid "Kid Gender"
+msgstr ""
+
+#. module: website_sale_product_custom_fields
+#: model_terms:ir.ui.view,arch_db:website_sale_product_custom_fields.product_custom_fields
+msgid "Loading complements..."
 msgstr ""
 
 #. module: website_sale_product_custom_fields

--- a/website_sale_product_custom_fields/security/ir_rule_data.xml
+++ b/website_sale_product_custom_fields/security/ir_rule_data.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <data noupdate="1">
+
+        <record id="product_template_is_complement_category_rule" model="ir.rule">
+            <field name="name">Read products linked to Complement Categories - Portal/Public</field>
+            <field name="model_id" ref="product.model_product_template"/>
+            <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal'))]"/>
+            <field name="domain_force">[('categ_id.is_complement_category', '=', True)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+
+    </data>
+</odoo>

--- a/website_sale_product_custom_fields/static/src/js/custom_script.js
+++ b/website_sale_product_custom_fields/static/src/js/custom_script.js
@@ -2,6 +2,8 @@ odoo.define('website.user_custom_code', function (require) {
     'use strict';
 
     var publicWidget = require('web.public.widget');
+    var core = require('web.core');
+    var _t = core._t;
     require('website_sale.website_sale');
 
     publicWidget.registry.CustomActions = publicWidget.Widget.extend({
@@ -58,6 +60,7 @@ odoo.define('website.user_custom_code', function (require) {
         },
 
         _setupPopupSelector: function () {
+            const self = this;
             const productVisualSelection = document.getElementById('product-visual-selection');
             const productSelectedInputId = document.getElementById('product-selected-id');
             const productSelectedImage = document.getElementById('product-selected-image');
@@ -66,18 +69,61 @@ odoo.define('website.user_custom_code', function (require) {
             const deleteSelectionBtn = document.getElementById('delete-selection-btn');
 
             const productSelectedPrice = document.getElementById('product-selected-price');
-
-            const popupProductImage = document.getElementById('popup-product-image');
-            const popupProductName = document.getElementById('popup-product-name');
-            const popupProductPrice = document.getElementById('popup-product-price');
-
             const customPopup = document.getElementById('custom-popup');
-            const closePopupBtn = document.getElementById('close-popup');
             const cancelSelectionBtn = document.getElementById('cancel-selection');
             const submitSelectionBtn = document.getElementById('submit-selection');
 
-            const availableProducts = document.querySelectorAll('.available-products');
+            const popupContentPlaceholder = document.getElementById('popup-content-placeholder');
+            let hasLoaded = false;
             let tempProductSelection = null;
+
+            function _loadComplements() {
+                const productId = productVisualSelection.dataset.productId;
+
+                if (popupContentPlaceholder) {
+                    popupContentPlaceholder.innerHTML = _t('<div class="text-center p-5"><div class="spinner-border" role="status"></div><p class="mt-2">Loading complements...</p></div>');
+                }
+
+                self._rpc({
+                    route: "/website/complements/get_products",
+                    params: {
+                        product_id: productId,
+                    },
+                }).then(function (data) {
+                    if (data.error) {
+                        popupContentPlaceholder.innerHTML = _t('<p class="text-danger p-3">Error: ') + data.error + '</p>';
+                    } else {
+                        popupContentPlaceholder.innerHTML = data;
+                        hasLoaded = true;
+
+                        _rebindPopupEvents();
+                    }
+                }).catch(function (error) {
+                    popupContentPlaceholder.innerHTML = _t('<p class="text-danger p-3">Error loading complements.</p>');
+                });
+            }
+
+            function _rebindPopupEvents() {
+                const availableProducts = customPopup.querySelectorAll('.available-products');
+
+                availableProducts.forEach(elemento => {
+                    elemento.addEventListener('click', function () {
+                        availableProducts.forEach(el => el.classList.remove('border-primary', 'selected'));
+                        this.classList.add('border-primary', 'selected');
+
+                        const selectedData = {
+                            id: this.dataset.productId,
+                            name: this.dataset.productName,
+                            imageUrl: this.dataset.productImageUrl,
+                            price: this.dataset.productPrice,
+                            currency: this.dataset.productCurrency
+                        };
+
+                        if (submitSelectionBtn) submitSelectionBtn.disabled = false;
+                        tempProductSelection = selectedData;
+                    });
+                });
+            }
 
             function openPopup() {
                 if (customPopup) {
@@ -85,43 +131,20 @@ odoo.define('website.user_custom_code', function (require) {
                     customPopup.classList.add('d-flex');
                 }
 
-                availableProducts.forEach(el => el.classList.remove('border-primary', 'selected'));
-                tempProductSelection = null;
-                if (submitSelectionBtn) submitSelectionBtn.disabled = true;
+                if (!hasLoaded) {
+                    _loadComplements();
+                } else {
+                    const availableProducts = customPopup.querySelectorAll('.available-products');
+                    availableProducts.forEach(el => el.classList.remove('border-primary', 'selected'));
+                    if (submitSelectionBtn) submitSelectionBtn.disabled = true;
 
-                const productId = productSelectedInputId?.value;
-                if (productId) {
-                    availableProducts.forEach(el => {
-                        if (el.dataset.productId === productId) {
-                            el.classList.add('border-primary', 'selected');
-                            tempProductSelection = {
-                                id: el.dataset.productId,
-                                name: el.dataset.productName,
-                                imageUrl: el.dataset.productImageUrl,
-                                price: el.dataset.productPrice,
-                                currency: el.dataset.productCurrency
-                            };
-
-                            const price = parseFloat(tempProductSelection.price || 0).toFixed(2);
-                            const currency = tempProductSelection.currency || '€';
-
-                            if (popupProductImage && popupProductName && popupProductPrice) {
-                                popupProductImage.src = tempProductSelection.imageUrl;
-                                popupProductImage.style.display = 'block';
-                                popupProductName.textContent = tempProductSelection.name;
-                                popupProductPrice.textContent = `+ ${price} ${currency} `;
-                                popupProductPrice.style.display = 'block';
-                            }
+                    const productId = productSelectedInputId?.value;
+                    if (productId) {
+                        const currentSelection = customPopup.querySelector(`.available-products[data-product-id="${productId}"]`);
+                        if(currentSelection) {
+                            currentSelection.classList.add('border-primary', 'selected');
                             if (submitSelectionBtn) submitSelectionBtn.disabled = false;
                         }
-                    });
-                } else {
-                    if (popupProductImage && popupProductName && popupProductPrice) {
-                        popupProductImage.style.display = 'none';
-                        popupProductImage.src = '';
-                        popupProductName.textContent = '';
-                        popupProductPrice.style.display = 'none';
-                        popupProductPrice.textContent = '';
                     }
                 }
             }
@@ -158,7 +181,6 @@ odoo.define('website.user_custom_code', function (require) {
                 });
             }
 
-            if (closePopupBtn) closePopupBtn.addEventListener('click', closePopup);
             if (cancelSelectionBtn) cancelSelectionBtn.addEventListener('click', closePopup);
             if (customPopup) {
                 customPopup.addEventListener('click', function (event) {
@@ -166,39 +188,17 @@ odoo.define('website.user_custom_code', function (require) {
                 });
             }
 
-            if (availableProducts.length > 0) {
-                availableProducts.forEach(elemento => {
-                    elemento.addEventListener('click', function () {
-                        availableProducts.forEach(el => el.classList.remove('border-primary', 'selected'));
-                        this.classList.add('border-primary', 'selected');
-
-                        tempProductSelection = {
-                            id: this.dataset.productId,
-                            name: this.dataset.productName,
-                            imageUrl: this.dataset.productImageUrl,
-                            price: this.dataset.productPrice,
-                            currency: this.dataset.productCurrency
-                        };
-
-                        const price = parseFloat(tempProductSelection.price || 0).toFixed(2);
-                        const currency = tempProductSelection.currency || '€';
-
-                        if (popupProductImage && popupProductName && popupProductPrice) {
-                            popupProductImage.src = tempProductSelection.imageUrl;
-                            popupProductImage.style.display = 'block';
-                            popupProductName.textContent = tempProductSelection.name;
-                            popupProductPrice.textContent = `+ ${price} ${currency}`;
-                            popupProductPrice.style.display = 'block';
-                        }
-
-                        if (submitSelectionBtn) submitSelectionBtn.disabled = false;
-                    });
-                });
-            }
-
             if (submitSelectionBtn) {
                 submitSelectionBtn.addEventListener('click', function () {
-                    if (tempProductSelection) {
+                    const selectedElement = customPopup.querySelector('.available-products.selected');
+                    if (selectedElement) {
+                        tempProductSelection = {
+                            id: selectedElement.dataset.productId,
+                            name: selectedElement.dataset.productName,
+                            imageUrl: selectedElement.dataset.productImageUrl,
+                            price: selectedElement.dataset.productPrice,
+                            currency: selectedElement.dataset.productCurrency
+                        };
                         productSelectedInputId.value = tempProductSelection.id;
 
                         productSelectedImage.src = tempProductSelection.imageUrl;

--- a/website_sale_product_custom_fields/views/complement_popup_template.xml
+++ b/website_sale_product_custom_fields/views/complement_popup_template.xml
@@ -1,0 +1,43 @@
+<odoo>
+    <template id="complement_popup_content" name="Complement Popup Content (AJAX)">
+        
+        <t t-foreach="complement_data" t-as="category_data">
+            
+            <t t-if="category_data['products']">
+                <h5 class="popup-category-title">
+                    <t t-esc="category_data['category_name']" />
+                </h5>
+
+                <div class="popup-product-container">
+                    <t t-foreach="category_data['products']" t-as="product_item">
+                        <div
+                            class="popup-product-card available-products shadow-sm"
+                            t-att-data-product-id="product_item['id']"
+                            t-att-data-product-name="product_item['name']"
+                            t-att-data-product-image-url="'/web/image/product.template/%s/image_1920' % product_item['id']"
+                            t-att-data-product-price="product_item['variant_price']"
+                            t-att-data-product-currency="product_item['currency_symbol']">
+
+                            <div class="popup-product-image">
+                                <img
+                                    t-attf-src="/web/image/product.template/#{product_item['id']}/image_128"
+                                    class="img-fluid" />
+                            </div>
+
+                            <div class="popup-product-info">
+                                <h6 class="popup-product-name">
+                                    <t t-esc="product_item['name']" />
+                                </h6>
+                                <small class="fw-bold">
+                                    +
+                                    <t t-esc="product_item['variant_price']" />
+                                    <t t-esc="product_item['currency_symbol']" />
+                                </small>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/website_sale_product_custom_fields/views/website_sale_product_template_inherit.xml
+++ b/website_sale_product_custom_fields/views/website_sale_product_template_inherit.xml
@@ -156,7 +156,7 @@
 
                     <div id="product-visual-selection"
                         class="card shadow-sm bg-white py-4 px-3 mx-auto"
-                        style="cursor: pointer; max-width: 300px; transition: box-shadow 0.3s ease;">
+                        t-att-data-product-id="product.id" style="cursor: pointer; max-width: 300px; transition: box-shadow 0.3s ease;">
 
                         <span id="product-selected-badge" class="badge bg-primary mt-3 fs-6 d-none"></span>
 
@@ -180,49 +180,11 @@
 
             <div id="custom-popup" class="popup-background d-none">
                 <div class="popup-content">
-
-                    <t t-set="categories" t-value="product.complement_category_ids" />
-
-                    <div class="popup-scroll-body">
-                        <t t-foreach="categories" t-as="category">
-                            <t t-set="products"
-                                t-value="request.env['product.template'].search([('categ_id', '=', category.id)])" />
-                            <t t-if="products">
-                                <h5 class="popup-category-title">
-                                    <t t-esc="category.name" />
-                                </h5>
-
-                                <div class="popup-product-container">
-                                    <t t-foreach="products" t-as="product_item">
-                                        <div
-                                            class="popup-product-card available-products shadow-sm"
-                                            t-att-data-product-id="product_item.id"
-                                            t-att-data-product-name="product_item.name"
-                                            t-att-data-product-image-url="'/web/image/product.template/%s/image_1920' % product_item.id"
-                                            t-att-data-product-price="product_item.product_variant_ids and product_item.product_variant_ids[0].lst_price or 0"
-                                            t-att-data-product-currency="product_item.currency_id.symbol">
-
-                                            <div class="popup-product-image">
-                                                <img
-                                                    t-attf-src="/web/image/product.template/#{product_item.id}/image_128"
-                                                    class="img-fluid" />
-                                            </div>
-
-                                            <div class="popup-product-info">
-                                                <h6 class="popup-product-name">
-                                                    <t t-esc="product_item.name" />
-                                                </h6>
-                                                <small class="fw-bold"> +<t
-                                                        t-esc="product_item.list_price" />
-                                                        <t
-                                                        t-esc="product.currency_id.symbol" />
-                                                </small>
-                                            </div>
-                                        </div>
-                                    </t>
-                                </div>
-                            </t>
-                        </t>
+                    <div class="popup-scroll-body" id="popup-content-placeholder">
+                        <div class="text-center p-5">
+                            <div class="spinner-border" role="status"></div>
+                            <p class="mt-2">Loading complements...</p>
+                        </div>
                     </div>
 
                     <div class="text-end mt-4 w-100" id="popup-buttons">
@@ -233,7 +195,7 @@
                     </div>
                 </div>
             </div>
-        </xpath>
+            </xpath>
     </template>
 
     <template id="cart_lines_custom_fields" inherit_id="website_sale.cart_lines"


### PR DESCRIPTION
Before this commit, users without sufficient permissions (e.g. portal users) could not see product complements in the website popup. This commit fixes the issue by adding a dedicated controller and adapting the JS logic and XML templates.

EDIT (@dalonsod): this depends on

* https://github.com/solvosci/slv-sale/pull/120